### PR TITLE
Compensate for terminal character aspect ratio

### DIFF
--- a/src/ascii_art.h
+++ b/src/ascii_art.h
@@ -40,16 +40,21 @@ uint8_t *load_image(const char *input_filepath, int *desired_width, int *desired
             exit(EXIT_FAILURE);
         }
 
-        *desired_height = height / (width / (float)*desired_width);
+        *desired_height = height / (width / (float)*desired_width) / 2;
 
         stbir_resize_uint8(
-            image, width, height, width * channels, 
+            image, width, height, width * channels,
             image, *desired_width, *desired_height, *desired_width * channels, channels
         );
     }
     else {
         *desired_width = width;
-        *desired_height = height;
+        *desired_height = height / 2;
+
+        stbir_resize_uint8(
+            image, width, height, width * channels,
+            image, *desired_width, *desired_height, *desired_width * channels, channels
+        );
     }
     return image;
 }


### PR DESCRIPTION
Terminal characters are roughly twice as tall as they are wide, so mapping image pixels 1:1 to characters produces output that appears horizontally squished.

This change halves the output row count in both the resize and no-resize branches of `load_image`, so the rendered ASCII preserves the source image's apparent aspect ratio when viewed in a terminal.